### PR TITLE
Ensure process output is consumed and fix RStreamHandler hanging for stop operation

### DIFF
--- a/RCaller/src/main/java/com/github/rcaller/rStuff/ROutputParser.java
+++ b/RCaller/src/main/java/com/github/rcaller/rStuff/ROutputParser.java
@@ -88,8 +88,7 @@ public class ROutputParser {
 
     try {
       FileInputStream in = new FileInputStream(XMLFile);
-      Reader reader = new InputStreamReader(in,"UTF-8");
-      InputSource is = new InputSource(reader);
+      InputSource is = new InputSource(in);
       is.setEncoding("UTF-8");
       document = builder.parse(is);
     } catch (Exception e) {

--- a/RCaller/src/main/java/com/github/rcaller/util/Globals.java
+++ b/RCaller/src/main/java/com/github/rcaller/util/Globals.java
@@ -28,6 +28,10 @@ package com.github.rcaller.util;
 import com.github.rcaller.graphics.DefaultTheme;
 import com.github.rcaller.graphics.GraphicsTheme;
 
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Arrays;
+
 public class Globals {
 
     public static String cranRepos = "http://cran.r-project.org";
@@ -44,8 +48,35 @@ public class Globals {
     public final static String about = "Author: Mehmet Hakan Satman - mhsatman@yahoo.com";
     public final static String license = "LGPL v3.0";
 
+    static {
+        if (isWindows()) {
+            String programFiles = System.getenv("ProgramFiles");
+            if (programFiles == null) {
+                programFiles = "C:\\Program Files";
+            }
+            File rBase = new File(programFiles, "R");
+            File[] rVersions = rBase.listFiles(new FileFilter() {
+                @Override
+                public boolean accept(File pathname) {
+                    return pathname.isDirectory() && pathname.getName().startsWith("R-");
+                }
+            });
+            Arrays.sort(rVersions);
+            File rHome = rVersions[rVersions.length - 1];
+            File rBin = new File(rHome, "bin");
+            if ("amd64".equals(System.getProperty("os.arch"))) {
+                File rBin64 = new File(rBin, "x64");
+                if (rBin64.exists()) {
+                    rBin = rBin64;
+                }
+            }
+            R_Windows = new File(rBin, "R.exe").getAbsolutePath();
+            RScript_Windows = new File(rBin, "Rscript.exe").getAbsolutePath();
+        }
+    }
+
     public static void detect_current_rscript() {
-        if (System.getProperty("os.name").contains("Windows")) {
+        if (isWindows()) {
             Rscript_current = RScript_Windows;
             R_current = R_Windows;
         } else {

--- a/RCaller/src/main/resources/runiversal.r
+++ b/RCaller/src/main/resources/runiversal.r
@@ -39,7 +39,7 @@ makevectorxml<-function(code,objt,name=""){
     if(is.vector(obj) && is.character(obj)){
         xmlcode<-paste(xmlcode,"<variable name=\"",varname,"\" type=\"character\">\n",sep="")
         for (i in obj){
-            xmlcode<-paste(xmlcode,"<v>",toString(i),"</v>",sep="")
+            xmlcode<-paste(xmlcode,"<v>",iconv(toString(i), to="UTF-8"),"</v>",sep="")
         }
         xmlcode<-paste(xmlcode,"</variable>\n")
     }

--- a/RCaller/src/test/java/com/github/rcaller/RunOnlineTest.java
+++ b/RCaller/src/test/java/com/github/rcaller/RunOnlineTest.java
@@ -162,7 +162,7 @@ public class RunOnlineTest {
         rcaller.setRExecutable(Globals.R_current);
 
         code.clear();
-        code.addRCode("a<-1:10");
+        code.addRCode("a<-1:100000");
 
         rcaller.setRCode(code);
 


### PR DESCRIPTION
Sorry for long reaction. 
I reviewed your comments about broken tests after my pull request. And I checked solution which fixes these tests. It has one downside - if R process still writing something to STDERR or STDOUT we can lose this result - this is reason why I used `join` instead of just `interrupt`, but I didn't expect that `readLine` hangs forever for if process terminated and nothing goes to process' input stream. I returned `join` and added workaround to handle both problems. 
It awaits until consumer thread stops activity (using `stillReading` flag), if nothing read during 100 milliseconds, then we just interrupt consumer thread. I checked tests and they pass.

P.S. (Bonus) I also slightly improved RScript and R detection for Windows.