### PR TITLE
Windows Compatibility

### DIFF
--- a/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
+++ b/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
@@ -205,8 +205,7 @@ public class RCaller {
         int returnCode;
         try {
             //this Process object is local to this method. Do not use the public one.
-            String source_path = com.github.rcaller.util.Globals.isWindows() ? rSourceFile.toString().replace("\\","/") : rSourceFile.toString();
-            process = exec(rCallerOptions.getrScriptExecutable() + " " + source_path);
+            process = exec(rCallerOptions.getrScriptExecutable() + " " + Globals.getSystemSpecificRPathParameter(rSourceFile));
             startStreamConsumers(process);
             returnCode = process.waitFor();
         } catch (Exception e) {

--- a/RCaller/src/main/java/com/github/rcaller/util/Globals.java
+++ b/RCaller/src/main/java/com/github/rcaller/util/Globals.java
@@ -164,4 +164,15 @@ public class Globals {
         setRscriptCurrent(rscript_current);
         setR_current(r_current);
     }
+
+    /**
+     * Convenience method to convert parameters for R that contain a path to the correct format.
+     *
+     * @param file object for which the absolute patch is needed
+     */
+    public static String getSystemSpecificRPathParameter(File file)
+    {
+        String path = isWindows() ? file.getAbsolutePath().toString().replace("\\","/") : file.getAbsolutePath().toString();
+        return path;
+    }
 }

--- a/RCaller/src/main/java/com/github/rcaller/util/RCodeUtils.java
+++ b/RCaller/src/main/java/com/github/rcaller/util/RCodeUtils.java
@@ -235,7 +235,7 @@ public class RCodeUtils {
             File file = File.createTempFile("dataFrame", ".csv");
             CSVFileWriter csvFileWriter = CSVFileWriter.create(file.getAbsolutePath());
             csvFileWriter.writeDataFrameToFile(dataFrame);
-            rCode.append(name).append(" <- read.csv(\"").append(file.getAbsolutePath()).append("\")\n");
+            rCode.append(name).append(" <- read.csv(\"").append(Globals.getSystemSpecificRPathParameter(file)).append("\")\n");
 
         } catch (IOException e) {
             Logger.getLogger(RCodeUtils.class.getName()).log(Level.WARNING, "Couldn't export data frame to csv-file!", e.getStackTrace());

--- a/RCaller/src/test/java/com/github/rcaller/FileStatusWatcherTest.java
+++ b/RCaller/src/test/java/com/github/rcaller/FileStatusWatcherTest.java
@@ -21,13 +21,19 @@ public class FileStatusWatcherTest {
                 FileWriter writer = null;
                 try {
                     writer = new FileWriter(testFile);
+                    writer.write(".");
+                    writer.flush();
+                    writer.close();
                 } catch (IOException ex) {
                     assertNull(ex);
                 }
                 while (true) {
                     try {
+                        //This test does not work on some windows configuration without closing the FileWriter in this loop.
+                        writer = new FileWriter(testFile, true);
                         writer.write(".");
                         writer.flush();
+                        writer.close();
                     } catch (IOException ex) {
                         break;
                     }

--- a/RCaller/src/test/java/com/github/rcaller/GridCapTest.java
+++ b/RCaller/src/test/java/com/github/rcaller/GridCapTest.java
@@ -5,6 +5,8 @@ import com.github.rcaller.rstuff.RCaller;
 import com.github.rcaller.rstuff.RCode;
 import java.io.File;
 import java.io.IOException;
+
+import com.github.rcaller.util.Globals;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -27,7 +29,11 @@ public class GridCapTest {
         
         File f = new File("Rplots.pdf");
 
-        assertEquals(-1397462731, f.hashCode());
+        if (Globals.isWindows()) {
+            assertEquals(902182165, f.hashCode());
+        } else {
+            assertEquals(-1397462731, f.hashCode());
+        }
         
         f.delete();
     }

--- a/RCaller/src/test/java/com/github/rcaller/UTF8Test.java
+++ b/RCaller/src/test/java/com/github/rcaller/UTF8Test.java
@@ -2,6 +2,7 @@ package com.github.rcaller;
 
 import com.github.rcaller.rstuff.RCaller;
 import com.github.rcaller.rstuff.RCode;
+import com.github.rcaller.util.Globals;
 import org.junit.Test;
 
 import java.io.BufferedWriter;
@@ -48,7 +49,7 @@ public class UTF8Test {
         writer.flush();
         writer.close();
         
-        code.addRCode("predictions <- read.csv(\""+tmpfile.toString()+"\",stringsAsFactors = FALSE)");
+        code.addRCode("predictions <- read.csv(\""+ Globals.getSystemSpecificRPathParameter(tmpfile)+"\",stringsAsFactors = FALSE)");
         caller.runAndReturnResult("predictions");
         
         String[] result = caller.getParser().getAsStringArray("ID");
@@ -71,7 +72,7 @@ public class UTF8Test {
         writer.flush();
         writer.close();
         
-        code.addRCode("predictions <- read.csv(\""+tmpfile.toString()+"\",stringsAsFactors = FALSE)");
+        code.addRCode("predictions <- read.csv(\""+Globals.getSystemSpecificRPathParameter(tmpfile)+"\",stringsAsFactors = FALSE)");
         caller.runAndReturnResult("predictions");
         
         String[] result = caller.getParser().getAsStringArray("ID");
@@ -94,7 +95,7 @@ public class UTF8Test {
         writer.flush();
         writer.close();
         
-        code.addRCode("predictions <- read.csv(\""+tmpfile.toString()+"\",stringsAsFactors = FALSE)");
+        code.addRCode("predictions <- read.csv(\""+Globals.getSystemSpecificRPathParameter(tmpfile)+"\",stringsAsFactors = FALSE)");
         caller.runAndReturnResult("predictions");
         
         String[] result = caller.getParser().getAsStringArray("ID");
@@ -117,7 +118,7 @@ public class UTF8Test {
         writer.flush();
         writer.close();
         
-        code.addRCode("predictions <- read.csv(\""+tmpfile.toString()+"\",stringsAsFactors = FALSE)");
+        code.addRCode("predictions <- read.csv(\""+Globals.getSystemSpecificRPathParameter(tmpfile)+"\",stringsAsFactors = FALSE)");
         caller.runAndReturnResult("predictions");
         
         String[] result = caller.getParser().getAsStringArray("ID");

--- a/RCaller/src/test/java/com/github/rcaller/io/RSerializerTest.java
+++ b/RCaller/src/test/java/com/github/rcaller/io/RSerializerTest.java
@@ -5,6 +5,8 @@ import com.github.rcaller.rstuff.RCaller;
 import com.github.rcaller.rstuff.RCode;
 import java.io.File;
 import java.io.IOException;
+
+import com.github.rcaller.util.Globals;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -27,7 +29,7 @@ public class RSerializerTest {
         RCaller caller = RCaller.create();
         RCode code = RCode.create();
 
-        code.addRCode("conn <- file(\"" + tmpFile.getCanonicalPath() + "\" , \"r\")");
+        code.addRCode("conn <- file(\"" + Globals.getSystemSpecificRPathParameter(tmpFile) + "\" , \"r\")");
         code.addRCode("x <- unserialize(conn)");
         caller.setRCode(code);
 
@@ -58,7 +60,7 @@ public class RSerializerTest {
         RCaller caller = RCaller.create();
         RCode code = RCode.create();
 
-        code.addRCode("conn <- file(\"" + tmpFile.getCanonicalPath() + "\" , \"r\")");
+        code.addRCode("conn <- file(\"" + Globals.getSystemSpecificRPathParameter(tmpFile) + "\" , \"r\")");
         code.addRCode("x <- unserialize(conn)");
         caller.setRCode(code);
 


### PR DESCRIPTION
- This version makes the RCaller fully compatible with Windows systems
- By the way: there seems to be an issue with the com.github.rcaller.GridCapTest. As far as I know, the [.hashCode()](https://docs.oracle.com/javase/7/docs/api/java/io/File.html#hashCode()) method of java.io.File does not really create a hash code of the file contents. I think something like the code below might be more appropriate. Unfortunately in different executions R seems to create slightly different files.

```
try {
      MessageDigest md = MessageDigest.getInstance("MD5");
      byte[] digest = md.digest(Files.readAllBytes(f.toPath()));
      assertEquals("691675778772B3155ADC3BDDDFAC88C2", DatatypeConverter.printHexBinary(digest));
} catch (NoSuchAlgorithmException nsa) {
      assertNull(nsa);
}
```