### PR TITLE
Added default R and Rscript path in Mac OS X and fixed some charset bugs.

### DIFF
--- a/RCaller/RCaller.iml
+++ b/RCaller/RCaller.iml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/RCaller/pom.xml
+++ b/RCaller/pom.xml
@@ -155,6 +155,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
         </plugins>
         <resources>
             <resource>

--- a/RCaller/src/main/java/com/github/rcaller/io/RSerializer.java
+++ b/RCaller/src/main/java/com/github/rcaller/io/RSerializer.java
@@ -25,6 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package com.github.rcaller.io;
 
+import com.github.rcaller.util.Globals;
+
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.FileOutputStream;
@@ -88,11 +90,11 @@ public class RSerializer {
     }
 
     byte[] getBytes(String s) {
-        return ((s + "\n").getBytes());
+        return ((s + "\n").getBytes(Globals.standardCharset));
     }
 
     byte[] getBytes(double d) {
-        return ((String.valueOf(d) + "\n").getBytes());
+        return ((String.valueOf(d) + "\n").getBytes(Globals.standardCharset));
     }
 
     public void save(String filename) throws IOException {

--- a/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
+++ b/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
@@ -34,8 +34,11 @@ import com.github.rcaller.graphics.GraphicsTheme;
 import com.github.rcaller.util.Globals;
 
 import java.io.*;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import static java.lang.String.join;
 
 /**
  *
@@ -191,7 +194,20 @@ public class RCaller {
     }
 
     private Process exec(String command) throws IOException {
-        return Runtime.getRuntime().exec(command);
+        String[] cmd = command.split(" ");
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        Map<String, String> env = pb.environment();
+        String localeAndCharset = join(".", Globals.standardLocale.toString(), Globals.standardCharset.toString());
+    
+        env.put("LC_COLLATE", localeAndCharset);
+        env.put("LC_CTYPE", localeAndCharset);
+        env.put("LC_MESSAGES", localeAndCharset);
+        env.put("LC_MONETARY", localeAndCharset);
+        env.put("LC_NUMERIC", localeAndCharset);
+        env.put("LC_TIME", localeAndCharset);
+        env.put("LC_ALL", localeAndCharset);
+    
+        return pb.start();
     }
 
     private void runRCode() throws ExecutionException {
@@ -271,7 +287,7 @@ public class RCaller {
             }
 
             try {
-                rInput.write(rCode.toString().getBytes());
+                rInput.write(rCode.toString().getBytes(Globals.standardCharset));
                 rInput.flush();
             } catch (IOException e) {
                 if (handleRFailure("Can not send the source code to R file due to: " + e.toString())) {
@@ -331,7 +347,7 @@ public class RCaller {
     public void StopRCallerOnline() {
         if (process != null) {
             try {
-                process.getOutputStream().write("q(\"no\")\n".getBytes());
+                process.getOutputStream().write("q(\"no\")\n".getBytes(Globals.standardCharset));
                 process.getOutputStream().flush();
                 process.getOutputStream().close();
             } catch (Exception e) {
@@ -411,10 +427,10 @@ public class RCaller {
         EventHandler eh = new EventHandler() {
             public void messageReceived(String senderName, String msg) {
                 try {
-                    o.write(senderName.getBytes());
-                    o.write(":".getBytes());
-                    o.write(msg.getBytes());
-                    o.write("\n".getBytes());
+                    o.write(senderName.getBytes(Globals.standardCharset));
+                    o.write(":".getBytes(Globals.standardCharset));
+                    o.write(msg.getBytes(Globals.standardCharset));
+                    o.write("\n".getBytes(Globals.standardCharset));
                     o.flush();
                 } catch (IOException ex) {
                     Logger.getLogger(RCaller.class.getName()).log(Level.SEVERE, null, ex);

--- a/RCaller/src/main/java/com/github/rcaller/util/Globals.java
+++ b/RCaller/src/main/java/com/github/rcaller/util/Globals.java
@@ -31,18 +31,27 @@ import com.github.rcaller.graphics.GraphicsTheme;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Locale;
 
 public class Globals {
 
     public static String cranRepos = "http://cran.r-project.org";
     public static String RScript_Windows = "C:\\Program Files\\R\\R-3.0.2\\bin\\Rscript.exe";
     public static String RScript_Linux = "/usr/bin/Rscript";
+    public static String RScript_Mac = "/usr/local/bin/Rscript";
     public static String Rscript_current;
+    
     public static String R_Windows = "C:\\Program Files\\R\\R-3.0.2\\bin\\R.exe";
     public static String R_Linux = "/usr/bin/R";
+    public static String R_Mac = "/usr/local/bin/R";
     public static String R_current;
-
+    
+    public static Locale standardLocale = Locale.getDefault();
+    public static Charset standardCharset = StandardCharsets.UTF_8;
+    
     public static GraphicsTheme theme = new DefaultTheme();
 
     public final static String version = "RCaller 3.0";
@@ -82,11 +91,16 @@ public class Globals {
         if (isWindows()) {
             Rscript_current = RScript_Windows;
             R_current = R_Windows;
+        } else if(isMac()) {
+            Rscript_current = RScript_Mac;
+            R_current = R_Mac;
         } else {
             Rscript_current = RScript_Linux;
             R_current = R_Linux;
         }
     }
+    
+    public static boolean isMac() { return System.getProperty("os.name").contains("Mac"); }
 
     public static boolean isWindows() {
         return System.getProperty("os.name").contains("Windows");
@@ -131,6 +145,8 @@ public class Globals {
         // otherwise detect_current_rscript() may overwrite Rscript_current unexpectedly
         if (isWindows()) {
             RScript_Windows = rscript_current;
+        } else if(isMac()) {
+            RScript_Mac = rscript_current;
         } else {
             RScript_Linux = rscript_current;
         }
@@ -149,6 +165,8 @@ public class Globals {
         // otherwise detect_current_rscript() may overwrite R_current unexpectedly
         if (isWindows()) {
             R_Windows = R_current;
+        } if(isMac()) {
+            R_Mac = R_current;
         } else {
             R_Linux = r_current;
         }
@@ -174,5 +192,27 @@ public class Globals {
     {
         String path = isWindows() ? file.getAbsolutePath().toString().replace("\\","/") : file.getAbsolutePath().toString();
         return path;
+    }
+    
+    /**
+     * Sets charset to be used with locale in JVM environment managed by ProcessBuilder.
+     *
+     * Default charset is UTF-8.
+     *
+     * @param charset charset to encode string before send through ProcessBuilder
+     */
+    public static void setChatset(Charset charset) {
+        standardCharset = charset;
+    }
+    
+    /**
+     * Sets locale to be used with charset in in JVM environment managed by ProcessBuilder.
+     *
+     * Default locale is the current locale for this instance of JVM.
+     *
+     * @param locale locale to be set with charset in environment managed by ProcessBuilder
+     */
+    public static void setLocale(Locale locale) {
+        standardLocale = locale;
     }
 }

--- a/RCaller/src/test/java/com/github/rcaller/GlobalsTest.java
+++ b/RCaller/src/test/java/com/github/rcaller/GlobalsTest.java
@@ -44,6 +44,9 @@ public class GlobalsTest {
         if(Globals.isWindows()){
             File myRScript = Globals.findFileRecursively(new File("c:\\Program Files\\R"), "Rscript.exe");
             assertEquals(myRScript.getName(), "Rscript.exe");
+        }else if(Globals.isMac()) {
+            File myRScript = Globals.findFileRecursively(new File("/usr/local/bin"), "Rscript");
+            assertEquals(myRScript.getName(), "Rscript");
         }else{
             File myRScript = Globals.findFileRecursively(new File("/usr/bin"), "Rscript");
             assertEquals(myRScript.getName(), "Rscript");


### PR DESCRIPTION
I'm using png package to plot maps but accents in the title (like í, ó, ã) were replaced by "..". This was fixed setting some environment variables in the [Process](https://docs.oracle.com/javase/8/docs/api/java/lang/Process.html) used to call R/Rscript executable.

![strcc_iv_2017_a4](https://user-images.githubusercontent.com/3957431/34113770-e9b29e32-e3f7-11e7-8690-6321de41ee12.png)

In order to fix the problem, I defined environment variables "**LC_COLLATE**", "**LC_CTYPE**", "**LC_MESSAGES**", "**LC_MONETARY**", "**LC_NUMERIC**", "**LC_TIME**" and "**LC_ALL**" using [ProcessBuilder](https://docs.oracle.com/javase/8/docs/api/java/lang/ProcessBuilder.html). This variables needs to be a string with locale dot charset (like "en_US.UTF-8"), so I added attributes Locale and Charset to Globals class. Default charset is UTF-8 and locale is the same as the current instance of JVM. Both attributes can be changed using setLocale(Locale) and setCharset(Charset).

![nsasm_iv_2017_a4](https://user-images.githubusercontent.com/3957431/34114642-74282832-e3fa-11e7-972c-c30369e95a11.png)

I also notice that there're no default paths to R/Rscript in Mac OS X , so I added then to Globals class.
