### PR TITLE
Add null check, tmpDir may not have been initialized

### DIFF
--- a/RCaller/pom.xml
+++ b/RCaller/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.github.jbytecode</groupId>
     <artifactId>RCaller</artifactId>
-    <version>3.0.1-SNAPSHOT</version>
+    <version>3.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>RCaller</name>

--- a/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
+++ b/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
@@ -441,7 +441,9 @@ public class RCaller {
             process.destroy();
             stopStreamConsumers();
             process = null;
-            deleteDirectory(new File(tmpDir));
+            if (tmpDir != null) {
+                deleteDirectory(new File(tmpDir));
+            }
         }
     }
 


### PR DESCRIPTION
`process` may have been initialized by calling `runAndReturnResult` or `runOnly` but `tmpDir` is only initialized in  `startOnlineProcess`