### PR TITLE
Respect RCallerOptions when checking for Arrow

### DIFF
--- a/RCaller/src/main/java/com/github/rcaller/io/RCodeIO.java
+++ b/RCaller/src/main/java/com/github/rcaller/io/RCodeIO.java
@@ -51,7 +51,7 @@ public class RCodeIO {
 
     private static RCodeIOGenerator getRCodeIOGenerator(RCallerOptions rCallerOptions) {
         if (rCallerOptions.useArrowIfAvailable()) {
-            if (ArrowBridge.isArrowAvailable()) {
+            if (ArrowBridge.isArrowAvailable(rCallerOptions)) {
                 //Use Arrow by default if enabled
                 return rCodeIOGeneratorArrow;
             } else {

--- a/RCaller/src/main/java/com/github/rcaller/io/ROutputParserArrow.java
+++ b/RCaller/src/main/java/com/github/rcaller/io/ROutputParserArrow.java
@@ -27,6 +27,7 @@ package com.github.rcaller.io;
 
 import com.github.rcaller.exception.ParseException;
 import com.github.rcaller.exception.XMLParseException;
+import com.github.rcaller.rstuff.RCallerOptions;
 import com.github.rcaller.rstuff.ROutputParser;
 import org.apache.commons.lang3.NotImplementedException;
 import org.w3c.dom.Document;
@@ -46,8 +47,16 @@ import java.util.ArrayList;
  * @author Kopilov Aleksandr
  */
 public class ROutputParserArrow implements ROutputParser {
-    ArrowBridge bridge = ArrowBridge.newInstance();
+    ArrowBridge bridge;
     URI ipcResourceURI;
+
+    public ROutputParserArrow() {
+        this.bridge = ArrowBridge.newInstance();
+    }
+
+    public ROutputParserArrow(RCallerOptions rCallerOptions) {
+        this.bridge = ArrowBridge.newInstance(rCallerOptions);
+    }
 
     @Override
     public Document getDocument() {

--- a/RCaller/src/main/java/com/github/rcaller/rstuff/RCallerOptions.java
+++ b/RCaller/src/main/java/com/github/rcaller/rstuff/RCallerOptions.java
@@ -37,6 +37,18 @@ public class RCallerOptions {
         this.failIfArrowNotAvailable = failIfArrowNotAvailable;
     }
 
+    public RCallerOptions(final RCallerOptions other) {
+        this.rScriptExecutable = other.rScriptExecutable;
+        this.rExecutable = other.rExecutable;
+        this.failurePolicy = other.failurePolicy;
+        this.maxWaitTime = other.maxWaitTime;
+        this.initialWaitTime = other.initialWaitTime;
+        this.rProcessStartUpOptions = new RProcessStartUpOptions(other.rProcessStartUpOptions);
+        this.retries = 0;
+        this.useArrowIfAvailable = other.useArrowIfAvailable;
+        this.failIfArrowNotAvailable = other.failIfArrowNotAvailable;
+    }
+
     /**
      *
      * @return a default RCallerOptions object

--- a/RCaller/src/main/java/com/github/rcaller/rstuff/ROutputParser.java
+++ b/RCaller/src/main/java/com/github/rcaller/rstuff/ROutputParser.java
@@ -57,9 +57,9 @@ public interface ROutputParser {
      */
     static ROutputParser create(RCallerOptions rCallerOptions) {
         if (rCallerOptions.useArrowIfAvailable()) {
-            if (ArrowBridge.isArrowAvailable()) {
+            if (ArrowBridge.isArrowAvailable(rCallerOptions)) {
                 //Use Arrow by default if enabled
-                return new ROutputParserArrow();
+                return new ROutputParserArrow(rCallerOptions);
             } else {
                 if (rCallerOptions.failIfArrowNotAvailable()) {
                     throw new ExecutionException("Arrow is enabled but not available");

--- a/RCaller/src/main/java/com/github/rcaller/rstuff/RProcessStartUpOptions.java
+++ b/RCaller/src/main/java/com/github/rcaller/rstuff/RProcessStartUpOptions.java
@@ -90,6 +90,34 @@ public class RProcessStartUpOptions {
         this.file = file;
     }
 
+    public RProcessStartUpOptions(final RProcessStartUpOptions other) {
+        this.save = other.save;
+        this.noSave = other.noSave;
+        this.noEnviron = other.noEnviron;
+        this.noSiteFile = other.noSiteFile;
+        this.noInitFile = other.noInitFile;
+        this.restore = other.restore;
+        this.noRestoreData = other.noRestoreData;
+        this.noRestoreHistory = other.noRestoreHistory;
+        this.noRestore = other.noRestore;
+        this.vanilla = other.vanilla;
+        this.noReadLine = other.noReadLine;
+        this.quiet = other.quiet;
+        this.silent = other.silent;
+        this.slave = other.slave;
+        this.interactive = other.interactive;
+        this.verbose = other.verbose;
+        this.maxPPSize = other.maxPPSize;
+        this.minNSize = other.minNSize;
+        this.minVSize = other.minVSize;
+        this.debugger = other.debugger;
+        this.debuggerArgs = other.debuggerArgs;
+        this.gui = other.gui;
+        this.arch = other.arch;
+        this.args = other.args;
+        this.file = other.file;
+    }
+
     /**
      *
      * @return the default RProcessStartUpOptions object


### PR DESCRIPTION
Currently, the check for arrow in R (`isArrowAvailableInR()`) always uses the hard-coded path constants in [Globals.java](https://github.com/jbytecode/rcaller/blob/master/RCaller/src/main/java/com/github/rcaller/util/Globals.java), and thus fails, if there is no R executable found under this path.
This still happens despite having the custom path to the r executable configured in the `RCallerOptions` when creating the `RCaller` object.

With this change, the `isArrowAvailableInR` method respects the executable provided in the passed `RCallerOptions` and uses it to check for arrow.