### PR TITLE
Use R startup options for Rscript and avoid saving workspace

### DIFF
--- a/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
+++ b/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
@@ -265,7 +265,7 @@ public class RCaller {
             stopStreamConsumers();
         }
         if (returnCode != 0) {
-            throw new ExecutionException("R command evaling " + rSourceFile.getAbsolutePath() + " failed with error. Reason: " + errorMessageSaver.getMessage());
+            throw new ExecutionException("R command evaluating " + rSourceFile.getAbsolutePath() + " failed with error. Reason: " + errorMessageSaver.getMessage());
         }
     }
 

--- a/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
+++ b/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
@@ -218,7 +218,7 @@ public class RCaller {
      * reason
      */
     public void runOnly() throws ExecutionException {
-        this.rCode.getCode().append("q(").append("\"").append("yes").append("\"").append(")\n");
+        this.rCode.getCode().append("q()\n");
         runRCode();
     }
 

--- a/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
+++ b/RCaller/src/main/java/com/github/rcaller/rstuff/RCaller.java
@@ -256,7 +256,8 @@ public class RCaller {
         errorMessageSaver.resetMessage();
         int returnCode;
         try {
-            process = exec(rCallerOptions.getrScriptExecutable() + " " + Globals.getSystemSpecificRPathParameter(rSourceFile));
+            String sourceFileParameter = Globals.getSystemSpecificRPathParameter(rSourceFile);
+            process = exec(rCallerOptions.getrScriptExecutable() + rCallerOptions.getStartUpOptionsAsCommand() + sourceFileParameter);
             startStreamConsumers(process);
             returnCode = process.waitFor();
         } catch (Exception e) {

--- a/doc/rcaller3/rcaller3.tex
+++ b/doc/rcaller3/rcaller3.tex
@@ -528,7 +528,7 @@ Since the \texttt{R} executable can be run with several arguments which can be s
 
 For a performance improvement, some implemented methods can be stored in \texttt{RProfile.site} and possibly be compiled into the \texttt{bytecode} using \texttt{cmpfun} from package \texttt{compiler} \cite{lim2015r,tierney2001compiling}. But in order to use the methods that are exported in this file, \texttt{RCaller} should not be started with the default option \texttt{--vanilla} or the option \texttt{--no-site-file}. 
 
-The static method \texttt{RProcessStartUpOptions} is encapsulated in the \texttt{RCallerOptions} class and it is called with default values in instantiation of a new \texttt{RCaller} object. Creating a \texttt{RStartUpOtions} object can be performed by either with the default values of arguments or with the user-defined values. Listing \ref{code_options_way1} shows the factory method for creating an \texttt{RPocessStartUpOptions} object with default arguments and the argument for the option \texttt{--vanilla} is set to \texttt{true}. 
+The static method \texttt{RProcessStartUpOptions} is encapsulated in the \texttt{RCallerOptions} class and it is called with default values in instantiation of a new \texttt{RCaller} object. Creating a \texttt{RStartUpOtions} object can be performed by either with the default values of arguments or with the user-defined values. Listing \ref{code_options_way1} shows the factory method for creating an \texttt{RProcessStartUpOptions} object with default arguments and the argument for the option \texttt{--vanilla} is set to \texttt{true}. 
 
 \begin{minipage}{\linewidth}
   \lstset{


### PR DESCRIPTION
My R scripts, which I started with `RCaller.runOnly()`, failed when run in a kubernetes container since R wanted to save the workspace in `.RData` but the PWD is read-only.

**Problem 1**: `RProcessStartUpOptions` are not used by `Rscript`

Following the RCaller documentation I assumed that the option `--vanilla` was used, but this was not the case. I added the `rCallerOptions.getStartUpOptionsAsCommand()` to the Rscript command since it understands all R options too.

**Problem 2**: `RCaller.runOnly` adds `q("yes")`

This overrides whatever the startup options may be. I changed that to `q()` which lets the startup options decide so adding `--save` leads to saving the workspace.

### Workaround
I could work around the problem by adding a `q("no")`, which makes the q("yes") be ignored.

### Tests
Which tests would you propose? Would it be sufficient to add an assertion to an existing test RCallerTest or should I add another test case or even class?

### Error message in container

    com.github.rcaller.exception.ExecutionException: R command evaling /tmp/rCaller9166028389620470667 failed with error. Reason: Error in gzfile(file, "wb") : cannot open the connection
    Calls: sys.save.image -> save.image -> save -> gzfile
    In addition: Warning message:
    In gzfile(file, "wb") :
      cannot open compressed file '.RDataTmp', probable reason 'Permission denied'